### PR TITLE
Fix navigation and add playful animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 Simple Description: This app is being created as part of a project for a Human-Computer Interactions Course.
              The project doesn't require actual coding an ios app, but I'm not great at drawing and wanted practice with swift and Xcode.
+
+## Backend Plan
+
+To make the prototype behave more like a real app, consider implementing a lightweight backend:
+
+1. **Data Storage** – Use CloudKit or Firebase to store restaurant menus, user favorites and profile information.
+2. **Authentication** – Integrate Sign in with Apple to keep things simple and secure.
+3. **Ordering** – Provide basic order objects stored in the database and update restaurant wait times based on submitted orders.
+4. **Payments** – For a real build you could integrate Apple Pay. During development, mock payment processing to avoid sensitive data handling.
+5. **Analytics & Logging** – Track user interactions to help refine the interface and catch crashes or errors.
+
+The current project structure already includes Core Data stubs, so hooking in a remote database and syncing with local storage would be a natural next step.

--- a/TigerEats/Models/Restaurant.swift
+++ b/TigerEats/Models/Restaurant.swift
@@ -1,7 +1,20 @@
-//
-//  Restaurant.swift
-//  TigerEats
-//
-//  Created by Shane John on 4/16/25.
-//
+import SwiftUI
 
+struct Restaurant: Identifiable {
+    enum CapacityLevel {
+        case empty
+        case kindaBusy
+        case busy
+    }
+
+    let id: Int
+    let imageName: String
+    let title: String
+    let address: String
+    let capacity: CapacityLevel
+    let openStatus: String
+    let waitTime: Int
+    let dietLabel: String
+    let costLabel: String
+    let borderColor: Color
+}

--- a/TigerEats/Views/Favorites/FavoritesView.swift
+++ b/TigerEats/Views/Favorites/FavoritesView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct FavoritesView: View {
+    var body: some View {
+        NavigationView {
+            Text("Your favorite spots will appear here.")
+                .navigationTitle("Favorites")
+        }
+    }
+}
+
+struct FavoritesView_Previews: PreviewProvider {
+    static var previews: some View {
+        FavoritesView()
+    }
+}

--- a/TigerEats/Views/Home/HomeScreenView.swift
+++ b/TigerEats/Views/Home/HomeScreenView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct HomeScreenView: View {
+    @State private var selectedTab = 0
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            RestaurantListView()
+                .tabItem {
+                    Image(systemName: selectedTab == 0 ? "house.fill" : "house")
+                        .scaleEffect(selectedTab == 0 ? 1.2 : 1.0)
+                    Text("Home")
+                }
+                .tag(0)
+
+            FavoritesView()
+                .tabItem {
+                    Image(systemName: selectedTab == 1 ? "star.fill" : "star")
+                        .scaleEffect(selectedTab == 1 ? 1.2 : 1.0)
+                    Text("Favorites")
+                }
+                .tag(1)
+
+            WalletView()
+                .tabItem {
+                    Image(systemName: selectedTab == 2 ? "creditcard.fill" : "creditcard")
+                        .scaleEffect(selectedTab == 2 ? 1.2 : 1.0)
+                    Text("Wallet")
+                }
+                .tag(2)
+
+            ProfileMenuView()
+                .tabItem {
+                    Image(systemName: selectedTab == 3 ? "person.fill" : "person")
+                        .scaleEffect(selectedTab == 3 ? 1.2 : 1.0)
+                    Text("Profile")
+                }
+                .tag(3)
+
+            SettingsView()
+                .tabItem {
+                    Image(systemName: selectedTab == 4 ? "gearshape.fill" : "gearshape")
+                        .scaleEffect(selectedTab == 4 ? 1.2 : 1.0)
+                    Text("Settings")
+                }
+                .tag(4)
+        }
+        .animation(.easeInOut, value: selectedTab)
+    }
+}
+
+struct HomeScreenView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeScreenView()
+    }
+}

--- a/TigerEats/Views/Profile/ProfileMenuView.swift
+++ b/TigerEats/Views/Profile/ProfileMenuView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct ProfileMenuView: View {
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                NavigationLink("Edit Profile", destination: EditProfileView())
+            }
+            .navigationTitle("Profile")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(.systemGroupedBackground))
+        }
+    }
+}
+
+struct ProfileMenuView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileMenuView()
+    }
+}

--- a/TigerEats/Views/RestaurantViews/RestaurantListView.swift
+++ b/TigerEats/Views/RestaurantViews/RestaurantListView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct RestaurantListView: View {
+    @State private var restaurants: [Restaurant] = [
+        Restaurant(id: 1,
+                   imageName: "Chicky",
+                   title: "Chick-fil-A",
+                   address: "201 Fernow St.",
+                   capacity: .kindaBusy,
+                   openStatus: "Open",
+                   waitTime: 12,
+                   dietLabel: "Gluten-Free",
+                   costLabel: "$$",
+                   borderColor: .red),
+        Restaurant(id: 2,
+                   imageName: "Pizza",
+                   title: "Pizza Palace",
+                   address: "99 College Ave",
+                   capacity: .busy,
+                   openStatus: "Closed",
+                   waitTime: 0,
+                   dietLabel: "Veggie",
+                   costLabel: "$$",
+                   borderColor: .blue)
+    ]
+
+    @State private var selectedCardId: Int?
+    @State private var swipeOffsets: [Int: CGFloat] = [:]
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 16) {
+                    ForEach(restaurants) { restaurant in
+                        RestaurantCard(
+                            restaurant: restaurant,
+                            selectedCardId: $selectedCardId,
+                            swipeOffsets: $swipeOffsets,
+                            onRemove: { withAnimation { restaurants.removeAll { $0.id == restaurant.id } } }
+                        )
+                        .padding(.horizontal)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+                }
+                .padding(.vertical)
+            }
+            .navigationTitle("Restaurants")
+        }
+        .animation(.spring(), value: restaurants)
+    }
+}
+
+struct RestaurantListView_Previews: PreviewProvider {
+    static var previews: some View {
+        RestaurantListView()
+    }
+}

--- a/TigerEats/Views/Settings/SettingsView.swift
+++ b/TigerEats/Views/Settings/SettingsView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        NavigationView {
+            List {
+                NavigationLink("Accessibility", destination: AccessibilitySettingsView())
+            }
+            .navigationTitle("Settings")
+        }
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
+    }
+}

--- a/TigerEats/Views/Shared/CapacityIndicator.swift
+++ b/TigerEats/Views/Shared/CapacityIndicator.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct CapacityIndicator: View {
+    let level: Restaurant.CapacityLevel
+
+    private var color: Color {
+        switch level {
+        case .empty: return .green
+        case .kindaBusy: return .yellow
+        case .busy: return .red
+        }
+    }
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 10, height: 10)
+            .overlay(Circle().stroke(Color.primary, lineWidth: 1))
+            .animation(.easeInOut, value: level)
+    }
+}

--- a/TigerEats/Views/Shared/CardModifier.swift
+++ b/TigerEats/Views/Shared/CardModifier.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct CardModifier: ViewModifier {
+    let isSelected: Bool
+    let anySelected: Bool
+    let selectedBorderColor: Color
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(isSelected ? 1.02 : 1)
+            .shadow(color: isSelected ? selectedBorderColor.opacity(0.5) : .clear,
+                    radius: isSelected ? 5 : 0)
+            .animation(.easeInOut, value: isSelected)
+    }
+}

--- a/TigerEats/Views/Shared/CircularProgressView.swift
+++ b/TigerEats/Views/Shared/CircularProgressView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct CircularProgressView: View {
+    let progress: Double
+
+    var body: some View {
+        Circle()
+            .trim(from: 0, to: progress)
+            .stroke(Color.blue, lineWidth: 4)
+            .rotationEffect(.degrees(-90))
+            .animation(.easeInOut, value: progress)
+    }
+}

--- a/TigerEats/Views/Wallet/WalletView.swift
+++ b/TigerEats/Views/Wallet/WalletView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct WalletView: View {
+    var body: some View {
+        NavigationView {
+            Text("Wallet coming soon")
+                .navigationTitle("Wallet")
+        }
+    }
+}
+
+struct WalletView_Previews: PreviewProvider {
+    static var previews: some View {
+        WalletView()
+    }
+}


### PR DESCRIPTION
## Summary
- flesh out `Restaurant` model
- create `CapacityIndicator`, `CardModifier`, and `CircularProgressView`
- implement restaurant list using animated cards
- implement animated TabView navigation in `HomeScreenView`
- add placeholder views for favorites, wallet, profile and settings
- outline next steps for backend in README

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840b1db30e08333ac2f18a2da407b05