### PR TITLE
Fix capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 Simple Description: This app is being created as part of a project for a Human-Computer Interactions Course.
-             The project doesn't require actual coding an ios app, but I'm not great at drawing and wanted practice with swift and Xcode.
+             The project doesn't require actual coding an iOS app, but I'm not great at drawing and wanted practice with Swift and Xcode.


### PR DESCRIPTION
## Summary
- update README capitalization of iOS and Swift

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project TigerEats.xcodeproj -scheme TigerEats -destination 'platform=iOS Simulator,name=iPhone 11' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b2ebc39083338e3aa1714627693f