### PR TITLE
Update view navigation and scaling

### DIFF
--- a/TigerEats/Views/RestaurantViews/RestaurantCardView.swift
+++ b/TigerEats/Views/RestaurantViews/RestaurantCardView.swift
@@ -33,12 +33,12 @@ struct RestaurantCard: View {
                 .cornerRadius(5)
                 .shadow(radius: 1)
 
-                NavigationLink(destination: HomeScreenView()) {
+                NavigationLink(destination: RestaurantProfileView(restaurant: restaurant)) {
                     Text("View Info")
                         .font(.headline)
                         .foregroundColor(.white)
                         .padding()
-                        .frame(width: 130, height: 35)
+                        .frame(width: UIScreen.main.bounds.width * 0.35, height: 35)
                         .background(Color.gray)
                         .cornerRadius(5)
                 }

--- a/TigerEats/Views/RestaurantViews/RestaurantProfileView.swift
+++ b/TigerEats/Views/RestaurantViews/RestaurantProfileView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct RestaurantProfileView: View {
+    let restaurant: Restaurant
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                Image(restaurant.imageName)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity)
+                    .cornerRadius(12)
+                    .padding(.bottom, 8)
+
+                Text(restaurant.title)
+                    .font(.title)
+                    .fontWeight(.bold)
+
+                Text(restaurant.address)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                HStack(spacing: 20) {
+                    Label(restaurant.openStatus,
+                          systemImage: restaurant.openStatus == "Open" ? "checkmark.circle" : "xmark.circle")
+                    Label("\(restaurant.waitTime) mins", systemImage: "clock")
+                }
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(restaurant.dietLabel, systemImage: "leaf")
+                    Label(restaurant.costLabel, systemImage: "dollarsign.circle")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 8)
+            }
+            .padding()
+        }
+        .navigationTitle("Restaurant Info")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+struct RestaurantProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            RestaurantProfileView(
+                restaurant: Restaurant(
+                    id: 1,
+                    imageName: "Chicky",
+                    title: "Chick-fil-A",
+                    address: "201 Fernow St.",
+                    capacity: .kindaBusy,
+                    openStatus: "Open",
+                    waitTime: 12,
+                    dietLabel: "Gluten‑Free",
+                    costLabel: "$$",
+                    borderColor: .red
+                )
+            )
+        }
+    }
+}

--- a/TigerEats/Views/Wallet/ReceiptDetailView.swift
+++ b/TigerEats/Views/Wallet/ReceiptDetailView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct ReceiptDetailView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "doc.text")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 80, height: 80)
+                .foregroundColor(.gray)
+            Text("Receipt details coming soon")
+                .font(.headline)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle("Receipt")
+    }
+}
+
+struct ReceiptDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            ReceiptDetailView()
+        }
+    }
+}

--- a/TigerEats/Views/Wallet/WalletView.swift
+++ b/TigerEats/Views/Wallet/WalletView.swift
@@ -3,8 +3,10 @@ import SwiftUI
 struct WalletView: View {
     var body: some View {
         NavigationView {
-            Text("Wallet coming soon")
-                .navigationTitle("Wallet")
+            List {
+                NavigationLink("Sample Receipt", destination: ReceiptDetailView())
+            }
+            .navigationTitle("Wallet")
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a simple `RestaurantProfileView`
- link restaurant cards to the new profile view and scale the link width relative to the screen
- stub out a `ReceiptDetailView` and link to it from `WalletView`

## Testing
- `swiftc -parse TigerEats/Views/RestaurantViews/RestaurantProfileView.swift`
- `swiftc -parse TigerEats/Views/Wallet/WalletView.swift`
- `swiftc -parse TigerEats/Views/Wallet/ReceiptDetailView.swift`
- `swiftc -parse TigerEats/Views/RestaurantViews/RestaurantCardView.swift`

------
https://chatgpt.com/codex/tasks/task_e_6840b6939cb083338bd5d4118c606af7